### PR TITLE
fix: render multiple list items, not lists

### DIFF
--- a/src/components/VersionList.vue
+++ b/src/components/VersionList.vue
@@ -3,14 +3,14 @@
     <ui5-busyindicator :active="!listReady" size="Large">
       <div>
         <ui5-list
-          v-for="version in versions"
-          v-bind:key="version.version"
           id="myList"
           class="card-content-child list"
           style="width: 100%"
           separators="None"
         >
           <ui5-li
+            v-for="version in versions"
+            v-bind:key="version.version"
             type="Inactive"
             :info="version.eom"
             :info-state="version.lts"


### PR DESCRIPTION
**Background**
For each version (in the versions array) a separate `<ui5-list>` with a single `<ui5-li>`has been rendered.

**Change**
Now, there is one `<ui5-list>`  with multiple `<ui5-li>`  items for each version.
As the `versions` array is a flat structure, there is no need to have multiple lists, we can put all list items in one list. This way, we can even benefit from the the item navigation, the user can  move the focus between items by pressing the ArrowDown/ArrowUp.